### PR TITLE
Update docs on building processors

### DIFF
--- a/docs/BUILDING_PROCESSORS.md
+++ b/docs/BUILDING_PROCESSORS.md
@@ -1,0 +1,487 @@
+# Building Processors for flowctl
+
+This guide is the focused companion to [`docs/building-components.md`](./building-components.md).
+
+It exists to make one part of the flagship story explicit:
+
+**prototype processors in nebu, then graduate the successful ones into production-ready flowctl processors.**
+
+That direction comes directly from:
+
+- [`docs/FLAGSHIP_AUDIT.md`](./FLAGSHIP_AUDIT.md)
+- [`docs/FLAGSHIP_SCOPE.md`](./FLAGSHIP_SCOPE.md)
+- [`docs/flowctl-vs-nebu.md`](./flowctl-vs-nebu.md)
+
+## The short version
+
+Use this path:
+
+```text
+Prototype in nebu
+  ↓
+Validate schema, naming, and behavior
+  ↓
+Keep the protobuf contract stable
+  ↓
+Wrap the logic as a flowctl processor
+  ↓
+Run and operate it with flowctl
+```
+
+If you're starting from scratch, do **not** begin by over-designing a production component.
+Start with a small, useful processor in nebu, prove it, then promote it.
+
+---
+
+## Why this is the recommended path
+
+Per the flagship scope, `flowctl` is the **production orchestration and operations layer**.
+It should be excellent at:
+
+- running pipelines
+- supervising components
+- tracking health and registration
+- exposing operator visibility
+
+It should not be the place where processor ideas are first explored.
+
+That exploratory work belongs to **nebu**.
+
+The practical split is:
+
+- **nebu**: fastest way to discover the right event shape and processor behavior
+- **flowctl**: best place to run that processor in a monitored, production-oriented pipeline
+
+---
+
+## Reference documents
+
+### In this repository
+
+- [`docs/FLAGSHIP_AUDIT.md`](./FLAGSHIP_AUDIT.md)
+- [`docs/FLAGSHIP_SCOPE.md`](./FLAGSHIP_SCOPE.md)
+- [`docs/flowctl-vs-nebu.md`](./flowctl-vs-nebu.md)
+- [`docs/building-components.md`](./building-components.md)
+- [`docs/component-publishing-guide.md`](./component-publishing-guide.md)
+- [`docs/processor-discovery.md`](./processor-discovery.md)
+- [`docs/REFERENCE_PROCESSORS.md`](./REFERENCE_PROCESSORS.md)
+
+### Nebu references
+
+- nebu processor guide: `https://github.com/withObsrvr/nebu/blob/main/docs/BUILDING_PROCESSORS.md`
+- nebu proto-first guide: `https://github.com/withObsrvr/nebu-processor-registry/blob/main/BUILDING_PROTO_PROCESSORS.md`
+- nebu community registry: `https://github.com/withObsrvr/nebu-processor-registry`
+- promotion guide: `https://github.com/withObsrvr/nebu-processor-registry/blob/main/docs/GRADUATING_TO_FLOWCTL.md`
+
+### SDK and shared proto references
+
+- flowctl SDK: `https://github.com/withObsrvr/flowctl-sdk`
+- SDK quickstart: `https://github.com/withObsrvr/flowctl-sdk/blob/main/docs/QUICKSTART.md`
+- shared protobuf definitions: `https://github.com/withObsrvr/flow-proto`
+
+---
+
+## What a flowctl processor is
+
+A flowctl processor is a standalone component that:
+
+- receives events from a source or another processor
+- transforms, filters, enriches, or extracts events
+- emits zero or more downstream events
+- registers with the flowctl control plane
+- exposes health and lifecycle behavior suitable for operations
+
+In other words, the **business logic** may start life in nebu, but the flowctl version adds:
+
+- control plane registration
+- health checks
+- heartbeats
+- production configuration
+- structured execution inside a pipeline
+
+---
+
+## The three processor patterns you should build first
+
+The best reference processors for flowctl are the same ones that teach the most in nebu.
+
+### 1. Ledger extractor processor
+Consumes raw Stellar ledger events and emits typed domain events.
+
+Examples:
+- `contract-events-processor`
+- `token-transfer-processor`
+- `contract-invocation-processor`
+
+This is the highest-value reference pattern because it shows how to:
+- consume `stellar.ledger.v1`
+- unmarshal protobuf payloads
+- emit stable domain events
+- preserve metadata needed by downstream sinks
+
+### 2. Typed filter processor
+Consumes a typed domain event and emits the same type, filtered.
+
+Examples:
+- `contract-filter-processor`
+- `asset-filter-processor`
+- `amount-filter-processor`
+
+This pattern is important because it teaches:
+- same-type input/output processors
+- config-driven filtering
+- easy chaining in pipelines
+
+### 3. Typed enrichment or normalization processor
+Consumes a typed event and emits a refined typed event.
+
+Examples:
+- `swap-normalizer-processor`
+- `trade-extractor-processor`
+- `dedup-processor`
+
+This pattern matters once the basic extractor/filter story is solid.
+
+---
+
+## Promotion rule: proto-first, then wrapper
+
+When a processor is likely to graduate into flowctl, build it in this order:
+
+### Step 1: Define or reuse a protobuf contract
+Use an existing event type from `flow-proto` when possible.
+If the event type does not exist yet, define it clearly before you lock in the processor behavior.
+
+### Step 2: Prove the logic in nebu
+Use nebu to answer:
+- is the event shape correct?
+- are the names correct?
+- does the processor emit what users actually need?
+- are important metadata fields present?
+
+### Step 3: Keep the event contract stable
+Promotion should not reinvent the schema.
+The flowctl processor should usually preserve:
+- event type name
+- payload protobuf type
+- metadata fields
+- config semantics where practical
+
+### Step 4: Wrap the logic with the flowctl SDK
+The wrapper should add:
+- flowctl registration
+- health checks
+- runtime config via env/config
+- operational logging
+
+### Step 5: Add an operator-facing example pipeline
+A reference processor is not finished until there is a copy-pasteable pipeline showing:
+- source
+- processor
+- sink
+- how to run it with `flowctl run`
+- how to inspect it with `flowctl status` and `flowctl processors`
+
+---
+
+## Recommended repository layout for a flowctl processor
+
+A good standalone flowctl processor repo should look like this:
+
+```text
+my-flowctl-processor/
+├── cmd/my-flowctl-processor/main.go
+├── internal/processor/
+│   ├── processor.go
+│   └── config.go
+├── proto/
+│   └── my_event.proto              # only if not using shared flow-proto types
+├── README.md
+├── Dockerfile
+├── go.mod
+├── go.sum
+└── .github/workflows/release.yml
+```
+
+If the logic already exists in a nebu processor repo, try to keep the extraction logic in a reusable package and keep the flowctl-specific code as a thin wrapper.
+
+---
+
+## Minimal development workflow
+
+## 1. Prototype in nebu
+
+Start from the nebu guides:
+
+- `nebu/docs/BUILDING_PROCESSORS.md`
+- `nebu-processor-registry/BUILDING_PROTO_PROCESSORS.md`
+
+Your goals in this phase:
+- settle the protobuf/event shape
+- test with bounded ledger ranges
+- confirm the output is useful
+- document examples
+
+## 2. Select the flowctl event types
+
+Prefer shared protobuf messages from `flow-proto`.
+
+Typical pattern:
+
+- input event type: `stellar.ledger.v1`
+- output event type: one of:
+  - `stellar.contract.events.v1`
+  - `stellar.token.transfer.v1`
+  - `stellar.contract.invocation.v1`
+
+## 3. Implement the flowctl wrapper
+
+At a high level, the processor does this:
+
+1. starts with `flowctl-sdk/pkg/processor`
+2. declares `InputType` and `OutputType`
+3. unmarshals the incoming protobuf payload
+4. calls your extraction or transform logic
+5. marshals one or more outgoing protobuf payloads
+6. returns the new events
+
+A schematic example:
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    flowctlv1 "github.com/withObsrvr/flow-proto/go/gen/flowctl/v1"
+    stellarv1 "github.com/withObsrvr/flow-proto/go/gen/stellar/v1"
+    sdkprocessor "github.com/withObsrvr/flowctl-sdk/pkg/processor"
+    "google.golang.org/protobuf/proto"
+)
+
+func main() {
+    proc := sdkprocessor.New(sdkprocessor.Config{
+        Name:        "contract-events-processor",
+        Description: "Extract Soroban contract events from Stellar ledgers",
+        Version:     "0.1.0",
+        InputType:   "stellar.ledger.v1",
+        OutputType:  "stellar.contract.events.v1",
+    })
+
+    proc.SetProcessFunc(func(ctx context.Context, event *flowctlv1.Event) ([]*flowctlv1.Event, error) {
+        var ledger stellarv1.RawLedger
+        if err := proto.Unmarshal(event.Payload, &ledger); err != nil {
+            return nil, fmt.Errorf("unmarshal ledger: %w", err)
+        }
+
+        batch, err := extractContractEvents(&ledger)
+        if err != nil {
+            return nil, fmt.Errorf("extract contract events: %w", err)
+        }
+
+        payload, err := proto.Marshal(batch)
+        if err != nil {
+            return nil, fmt.Errorf("marshal contract event batch: %w", err)
+        }
+
+        out := &flowctlv1.Event{
+            Id:        event.Id + "-contract-events",
+            Type:      "stellar.contract.events.v1",
+            Timestamp: event.Timestamp,
+            Payload:   payload,
+        }
+
+        return []*flowctlv1.Event{out}, nil
+    })
+
+    if err := proc.Run(); err != nil {
+        log.Fatal(err)
+    }
+}
+```
+
+The exact SDK API may evolve; use the latest examples in `flowctl-sdk` as the canonical implementation reference.
+
+---
+
+## 4. Add pipeline examples immediately
+
+Every reference processor should ship with at least one small pipeline example.
+
+Example:
+
+```yaml
+apiVersion: flowctl/v1
+kind: Pipeline
+metadata:
+  name: contract-events-reference
+
+spec:
+  driver: process
+
+  sources:
+    - id: stellar-source
+      type: stellar-live-source@v1.0.0
+      config:
+        network_passphrase: "Test SDF Network ; September 2015"
+        backend_type: RPC
+        rpc_endpoint: https://soroban-testnet.stellar.org
+        start_ledger: 54000000
+
+  processors:
+    - id: contract-events
+      type: contract-events-processor@v1.0.0
+      inputs: ["stellar-source"]
+      config:
+        network_passphrase: "Test SDF Network ; September 2015"
+
+  sinks:
+    - id: duckdb-sink
+      type: duckdb-consumer@v1.0.0
+      inputs: ["contract-events"]
+      config:
+        database_path: ./reference.duckdb
+```
+
+---
+
+## How to choose which processor graduates first
+
+Promote a nebu processor into flowctl when all of these are true:
+
+- the schema is stable enough to support downstream users
+- the processor solves a common, repeatable pipeline need
+- it is useful in docs, demos, and quickstarts
+- it benefits from health monitoring and long-running operation
+- it is not just a one-off query helper
+
+Good candidates:
+- contract events
+- token transfers
+- contract invocations
+- typed filters used in many pipelines
+
+Less urgent candidates:
+- highly ad hoc transforms
+- one-off analytics helpers
+- processors that are mainly useful in shell pipelines only
+
+---
+
+## What a good reference processor must include
+
+A reference processor is more than code.
+It should include:
+
+### Required
+- stable name
+- clear input and output event types
+- README with a one-minute explanation
+- at least one runnable flowctl pipeline example
+- tests for the core transform/extraction logic
+- release automation and image publishing
+- health-port behavior that works under flowctl
+
+### Strongly recommended
+- matching nebu prototype or precursor
+- protobuf schema docs
+- migration notes from nebu to flowctl
+- example sink integrations
+- sample queries for DuckDB or Postgres consumers
+
+---
+
+## Suggested initial processor set
+
+See [`docs/REFERENCE_PROCESSORS.md`](./REFERENCE_PROCESSORS.md) for the proposed starter set.
+
+The short recommendation is:
+
+### First wave
+1. `contract-events-processor`
+2. `token-transfer-processor`
+3. `contract-filter-processor`
+
+### Second wave
+4. `contract-invocation-processor`
+5. `amount-filter-processor`
+6. `dedup-processor`
+
+This gives flowctl both:
+- **extractor references**
+- **transform references**
+
+That mirrors what made nebu useful for processor builders.
+
+---
+
+## Testing checklist
+
+Before calling a processor a reference implementation, verify:
+
+### Logic
+- unit tests cover happy path and malformed inputs
+- protobuf payloads unmarshal and marshal correctly
+- output event type names are correct
+
+### Runtime
+- component registers with the control plane
+- `flowctl status` shows it as healthy
+- `flowctl processors list` shows expected input/output types
+- shutdown is graceful
+
+### Operator UX
+- pipeline example works with `flowctl validate`
+- pipeline example works with `flowctl run`
+- logs are readable
+- config errors fail clearly
+
+### Documentation
+- README includes copy-paste examples
+- docs state input/output event types explicitly
+- docs explain when to use nebu vs flowctl
+
+---
+
+## Publishing and distribution
+
+When the processor is ready to distribute:
+
+1. publish a container image
+2. include metadata for discovery
+3. document versioned references in pipeline examples
+4. make sure `type:`-based resolution is possible where applicable
+
+Use:
+- [`docs/component-publishing-guide.md`](./component-publishing-guide.md)
+- [`docs/component-image-spec.md`](./component-image-spec.md)
+
+---
+
+## One strong rule for this flagship cycle
+
+For this cycle, optimize for:
+
+- a few excellent processors
+- excellent docs
+- excellent runnable examples
+
+Do **not** optimize for a huge catalog before the promotion path is clear.
+
+The flagship story gets stronger when users can see:
+
+```text
+nebu prototype
+  ↓
+shared proto contract
+  ↓
+flowctl reference processor
+  ↓
+runnable example pipeline
+  ↓
+operator visibility with status and pipelines commands
+```
+
+That is the ecosystem loop we should make obvious.

--- a/docs/REFERENCE_PROCESSORS.md
+++ b/docs/REFERENCE_PROCESSORS.md
@@ -1,0 +1,363 @@
+# Flowctl Reference Processors
+
+This document defines the initial reference processor set for `flowctl`.
+
+It operationalizes the direction in:
+
+- [`docs/FLAGSHIP_AUDIT.md`](./FLAGSHIP_AUDIT.md)
+- [`docs/FLAGSHIP_SCOPE.md`](./FLAGSHIP_SCOPE.md)
+- [`docs/BUILDING_PROCESSORS.md`](./BUILDING_PROCESSORS.md)
+
+The goal is not to create a giant catalog first.
+The goal is to create a **small, high-signal set** of processors that teach users how flowctl processors are built, configured, run, and operated.
+
+---
+
+## Why reference processors matter
+
+Reference processors do four jobs at once:
+
+1. **teach the processor model**
+2. **prove the nebu → flowctl promotion path**
+3. **support example and quickstart pipelines**
+4. **give the flagship runtime real, documented building blocks**
+
+Per the flagship scope, this is exactly the kind of work that strengthens `flowctl` as the production layer.
+
+---
+
+## Selection criteria
+
+A processor should be considered a reference processor if it is:
+
+- broadly useful
+- easy to explain
+- valuable in production pipelines
+- a good example of one processor pattern
+- backed by a nebu prototype or direct nebu equivalent when possible
+
+We want the starter set to cover the most important processor shapes:
+
+- **extract from ledgers**
+- **filter typed events**
+- **transform or normalize typed events**
+
+---
+
+## Starter set
+
+## 1. contract-events-processor
+
+**Role:** extractor
+
+**Why it belongs in the first wave**
+- already present in flowctl examples and metadata
+- highly relevant to Soroban/Stellar users
+- natural demonstration of `stellar.ledger.v1 -> stellar.contract.events.v1`
+- directly supports flagship quickstarts
+
+**Input type**
+- `stellar.ledger.v1`
+
+**Output type**
+- `stellar.contract.events.v1`
+
+**Nebu precursor**
+- `contract-events` in nebu / nebu-processor-registry
+
+**Current in-repo signal**
+- `docker/contract-events-processor/metadata.json`
+- `examples/quickstart/testnet-duckdb-pipeline.yaml`
+
+**What this reference should teach**
+- consuming raw ledgers
+- protobuf payload decoding
+- emitting typed event batches
+- using the processor in a full source → processor → sink pipeline
+
+**Required example pipeline**
+- Stellar source → contract-events-processor → DuckDB sink
+
+---
+
+## 2. token-transfer-processor
+
+**Role:** extractor
+
+**Why it belongs in the first wave**
+- token transfers are one of the most understandable domain events
+- great for demos, analytics, and onboarding
+- maps cleanly from a proven nebu pattern into flowctl
+
+**Input type**
+- `stellar.ledger.v1`
+
+**Output type**
+- `stellar.token.transfer.v1`
+
+**Nebu precursor**
+- `token-transfer`
+- related production lineage: `ttp-processor`
+
+**What this reference should teach**
+- extracting a high-value domain event from ledgers
+- preserving metadata for ordering and sinks
+- using shared protobuf contracts
+- how a processor becomes the center of a pipeline story
+
+**Required example pipeline**
+- Stellar source → token-transfer-processor → Postgres or DuckDB sink
+
+---
+
+## 3. contract-filter-processor
+
+**Role:** typed filter transform
+
+**Why it belongs in the first wave**
+- shows the simplest useful transform pattern
+- teaches same-type input/output processors
+- easy to compose after `contract-events-processor`
+- mirrors the small-but-useful transform processors that made nebu approachable
+
+**Input type**
+- `stellar.contract.events.v1`
+
+**Output type**
+- `stellar.contract.events.v1`
+
+**Nebu precursor**
+- closest equivalents: `contract-filter`, `asset-filter`, `amount-filter`
+
+**What this reference should teach**
+- config-driven filtering
+- zero-or-one output per input event or batch
+- chaining processors together
+- writing docs for common operator knobs like contract ID allowlists
+
+**Required example pipeline**
+- Stellar source → contract-events-processor → contract-filter-processor → sink
+
+---
+
+## Second wave
+
+These should come after the starter set is solid.
+
+## 4. contract-invocation-processor
+
+**Role:** extractor
+
+**Input type**
+- `stellar.ledger.v1`
+
+**Output type**
+- `stellar.contract.invocation.v1`
+
+**Nebu precursor**
+- `contract-invocation`
+
+**Why it matters**
+- strong developer-facing value
+- useful for app observability and protocol indexing
+- good advanced extractor reference
+
+---
+
+## 5. amount-filter-processor
+
+**Role:** typed filter transform
+
+**Likely input/output types**
+- `stellar.token.transfer.v1` → `stellar.token.transfer.v1`
+
+**Nebu precursor**
+- `amount-filter`
+
+**Why it matters**
+- simple, obvious, reusable transform
+- great for example chaining after token transfer extraction
+
+---
+
+## 6. dedup-processor
+
+**Role:** normalization / transform
+
+**Likely input/output types**
+- same-type passthrough with duplicate suppression
+
+**Nebu precursor**
+- `dedup`
+
+**Why it matters**
+- operationally useful
+- demonstrates stateful or semi-stateful processor behavior
+- valuable for real pipelines, not just tutorials
+
+---
+
+## Reference patterns we need to cover
+
+The reference set should deliberately cover these patterns.
+
+| Pattern | Reference processor |
+|---|---|
+| Ledger extractor | `contract-events-processor` |
+| Ledger extractor | `token-transfer-processor` |
+| Same-type filter | `contract-filter-processor` |
+| Advanced extractor | `contract-invocation-processor` |
+| Numeric filter | `amount-filter-processor` |
+| Dedup / normalization | `dedup-processor` |
+
+If we only ship extractors, users will not learn how to build transforms.
+If we only ship filters, users will not learn how to decode ledgers.
+We need both.
+
+---
+
+## Proposed implementation order
+
+## Phase 1: flagship minimum
+
+1. harden `contract-events-processor`
+2. build `token-transfer-processor`
+3. build `contract-filter-processor`
+4. document all three together
+5. add runnable pipelines for all three
+
+This gives flowctl:
+- one existing Soroban-centric extractor
+- one high-signal transfer extractor
+- one simple transform processor
+
+That is enough to create a credible reference story.
+
+## Phase 2: deepen the catalog
+
+6. build `contract-invocation-processor`
+7. build `amount-filter-processor`
+8. build `dedup-processor`
+
+This adds advanced extraction and transform examples without over-expanding the surface too early.
+
+---
+
+## Processor-by-processor deliverables
+
+Each reference processor should ship with the same package of artifacts.
+
+### Code
+- standalone repo or example repo
+- flowctl SDK-based implementation
+- tests for extraction or transform logic
+
+### Contract
+- explicit input type
+- explicit output type
+- protobuf definitions or shared proto references
+- versioned image tag
+
+### Docs
+- README
+- config reference
+- example pipeline YAML
+- operator notes: ports, health, status expectations
+- relation to the nebu precursor
+
+### Ops
+- container image publishing
+- health endpoint
+- visible registration metadata
+- discoverable through `flowctl processors`
+
+---
+
+## Suggested example chains
+
+These are the examples that should appear in docs and demos.
+
+### Chain A: Soroban contract events
+
+```text
+stellar-live-source
+  → contract-events-processor
+  → duckdb-consumer
+```
+
+### Chain B: Soroban contract events with filter
+
+```text
+stellar-live-source
+  → contract-events-processor
+  → contract-filter-processor
+  → postgres-consumer
+```
+
+### Chain C: Token transfers
+
+```text
+stellar-live-source
+  → token-transfer-processor
+  → duckdb-consumer
+```
+
+### Chain D: Token transfers with thresholding
+
+```text
+stellar-live-source
+  → token-transfer-processor
+  → amount-filter-processor
+  → webhook or postgres sink
+```
+
+These chains are good because they are both:
+- teachable
+- operationally relevant
+
+---
+
+## What “reference quality” means
+
+A processor is reference quality when a new user can:
+
+1. understand what it does in under a minute
+2. run it in a documented pipeline
+3. inspect it with `flowctl status` and `flowctl processors`
+4. read the config knobs without reading source
+5. use it as a template for a new processor
+
+If those are not true, it is not yet a reference processor.
+
+---
+
+## Relationship to nebu
+
+These processors should usually start in nebu because nebu is the best place to:
+
+- prove the event shape
+- test the extraction logic quickly
+- refine schemas with real data
+- iterate without orchestration overhead
+
+Then flowctl becomes the production wrapper and operations layer.
+
+That means each reference processor should explicitly point back to its precursor, for example:
+
+- `token-transfer` → `token-transfer-processor`
+- `contract-events` → `contract-events-processor`
+- `contract-filter` → `contract-filter-processor`
+
+This promotion path is a core part of the flagship ecosystem story.
+
+---
+
+## Immediate next steps
+
+1. keep `contract-events-processor` as the first-class existing reference
+2. create a `token-transfer-processor` reference implementation
+3. create a simple `contract-filter-processor` reference implementation
+4. add example pipelines that chain them
+5. keep all docs cross-linked from [`docs/BUILDING_PROCESSORS.md`](./BUILDING_PROCESSORS.md)
+
+That is the smallest useful set that makes the story coherent.

--- a/docs/building-components.md
+++ b/docs/building-components.md
@@ -2,6 +2,21 @@
 
 This guide covers building custom sources, processors, and sinks using the flowctl-sdk.
 
+If you are specifically building **processors**, read this first:
+
+- [`docs/BUILDING_PROCESSORS.md`](./BUILDING_PROCESSORS.md) — focused guide for processor authors
+- [`docs/REFERENCE_PROCESSORS.md`](./REFERENCE_PROCESSORS.md) — the initial reference processor set for the flagship cycle
+
+Those documents make the intended path explicit:
+
+```text
+Prototype in nebu
+  ↓
+stabilize schema and behavior
+  ↓
+promote to a production-ready flowctl processor
+```
+
 ## Table of Contents
 
 - [Overview](#overview)

--- a/examples/README.md
+++ b/examples/README.md
@@ -46,7 +46,7 @@ This directory contains example pipeline configurations demonstrating various fl
 → Start with [Getting Started Guide](getting-started/README.md)
 
 **"I want to build a custom pipeline"**
-→ Study the [Building Components Guide](../docs/building-components.md) and see the [Contract Events Pipeline](https://github.com/withObsrvr/flowctl-sdk/tree/main/examples/contract-events-pipeline) for a real working example
+→ Study the [Building Components Guide](../docs/building-components.md), the focused [Building Processors Guide](../docs/BUILDING_PROCESSORS.md), and see the [Contract Events Pipeline](https://github.com/withObsrvr/flowctl-sdk/tree/main/examples/contract-events-pipeline) for a real working example
 
 **"I want to see a real production pipeline"**
 → Check out the [Contract Events Pipeline](https://github.com/withObsrvr/flowctl-sdk/tree/main/examples/contract-events-pipeline) - a complete working pipeline with Stellar source, processor, and PostgreSQL consumer
@@ -166,6 +166,7 @@ spec:
 - **[Main README](../README.md)** - flowctl overview and installation
 - **[Configuration Guide](../docs/configuration.md)** - Complete schema reference
 - **[Building Components Guide](../docs/building-components.md)** - How to build sources, processors, sinks
+- **[Building Processors Guide](../docs/BUILDING_PROCESSORS.md)** - How to prototype in nebu and graduate processors into flowctl
 - **[Getting Started](getting-started/README.md)** - Comprehensive beginner guide
 
 ### Real-World Examples
@@ -191,7 +192,7 @@ spec:
 
 **Intermediate:**
 1. Read [Building Components Guide](../docs/building-components.md)
-2. Build a simple source or sink
+2. Build a simple processor, source, or sink
 3. Create your own pipeline based on the template above
 
 **Advanced:**

--- a/scripts/smoke-token-transfer-release.sh
+++ b/scripts/smoke-token-transfer-release.sh
@@ -1,0 +1,416 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Smoke-test a released token-transfer-processor binary against local flowctl.
+#
+# What this verifies:
+# - released processor artifact downloads and runs
+# - flowctl validate works
+# - flowctl run works
+# - component registration works
+# - flowctl status works
+# - flowctl processors list works
+# - flowctl pipelines active works (with retry)
+# - flowctl pipelines run-info works
+# - flowctl pipelines stop works
+# - sink receives real stellar.token.transfer.v1 events
+#
+# Usage:
+#   ./scripts/smoke-token-transfer-release.sh [v0.1.3]
+#
+# Optional env:
+#   FLOWCTL_SDK_VERSION=v0.1.0
+#   FLOW_PROTO_VERSION=v0.1.3
+#   START_LEDGER=60200000
+#   END_LEDGER=60200100
+#   RPC_ENDPOINT=https://archive-rpc.lightsail.network
+#   NETWORK_PASSPHRASE='Public Global Stellar Network ; September 2015'
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+RELEASE_TAG="${1:-v0.1.3}"
+WORK_DIR=$(mktemp -d /tmp/flowctl-token-transfer-smoke-XXXXXX)
+START_LEDGER="${START_LEDGER:-60200000}"
+END_LEDGER="${END_LEDGER:-60200100}"
+RPC_ENDPOINT="${RPC_ENDPOINT:-https://archive-rpc.lightsail.network}"
+NETWORK_PASSPHRASE="${NETWORK_PASSPHRASE:-Public Global Stellar Network ; September 2015}"
+FLOWCTL_BIN="$ROOT_DIR/bin/flowctl"
+FLOWCTL_SDK_VERSION="${FLOWCTL_SDK_VERSION:-v0.1.0}"
+FLOW_PROTO_VERSION="${FLOW_PROTO_VERSION:-v0.1.3}"
+LOG_DIR="$WORK_DIR/flowctl-logs"
+
+cleanup() {
+  if [[ -n "${FLOWCTL_PID:-}" ]] && kill -0 "$FLOWCTL_PID" 2>/dev/null; then
+    kill -INT "$FLOWCTL_PID" 2>/dev/null || true
+    sleep 2
+    kill -KILL "$FLOWCTL_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required command: $1" >&2
+    exit 1
+  }
+}
+
+wait_for_contains() {
+  local timeout="$1"
+  local needle="$2"
+  shift 2
+  local start now out
+  start=$(date +%s)
+  while true; do
+    if out=$("$@" 2>&1); then
+      if grep -q "$needle" <<<"$out"; then
+        printf '%s\n' "$out"
+        return 0
+      fi
+    fi
+    now=$(date +%s)
+    if (( now - start >= timeout )); then
+      echo "$out" >&2
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+free_port() {
+  perl -MIO::Socket::INET -e '$s=IO::Socket::INET->new(Listen=>1,LocalAddr=>"127.0.0.1",LocalPort=>0,Proto=>"tcp") or die $!; print $s->sockport; close($s);'
+}
+
+require_cmd gh
+require_cmd go
+require_cmd tar
+require_cmd perl
+
+mkdir -p "$WORK_DIR" "$LOG_DIR"
+CONTROL_PLANE_PORT=$(free_port)
+SOURCE_PORT=$(free_port)
+PROCESSOR_PORT=$(free_port)
+SINK_PORT=$(free_port)
+SOURCE_HEALTH_PORT=$(free_port)
+PROCESSOR_HEALTH_PORT=$(free_port)
+SINK_HEALTH_PORT=$(free_port)
+
+echo "work dir: $WORK_DIR"
+echo "control plane port: $CONTROL_PLANE_PORT"
+
+cat > "$WORK_DIR/go.mod" <<EOF
+module token-transfer-smoke
+
+go 1.26.1
+
+require (
+	github.com/stellar/go-stellar-sdk v0.5.0
+	github.com/withObsrvr/flowctl-sdk ${FLOWCTL_SDK_VERSION}
+	github.com/withObsrvr/flow-proto ${FLOW_PROTO_VERSION}
+	google.golang.org/protobuf v1.36.11
+)
+EOF
+
+cat > "$WORK_DIR/source.go" <<'EOF'
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strconv"
+	"syscall"
+
+	ledgerbackend "github.com/stellar/go-stellar-sdk/ingest/ledgerbackend"
+	"github.com/stellar/go-stellar-sdk/xdr"
+	flowctlpkg "github.com/withObsrvr/flowctl-sdk/pkg/flowctl"
+	"github.com/withObsrvr/flowctl-sdk/pkg/source"
+	flowctlv1 "github.com/withObsrvr/flow-proto/go/gen/flowctl/v1"
+	stellarv1 "github.com/withObsrvr/flow-proto/go/gen/stellar/v1"
+	"google.golang.org/protobuf/proto"
+)
+
+func main() {
+	componentID := getenv("FLOWCTL_COMPONENT_ID", getenv("COMPONENT_ID", "stellar-source"))
+	port := getenv("PORT", ":50051")
+	healthPort := mustInt(getenv("HEALTH_PORT", "8088"))
+	rpcEndpoint := getenv("RPC_ENDPOINT", "https://archive-rpc.lightsail.network")
+	startLedger := uint32(mustInt(getenv("START_LEDGER", "60200000")))
+	endLedger := uint32(mustInt(getenv("END_LEDGER", "60200100")))
+	flowctlEndpoint := getenv("FLOWCTL_ENDPOINT", "127.0.0.1:8080")
+	enableFlowctl := getenv("ENABLE_FLOWCTL", "false") == "true"
+
+	config := source.DefaultConfig()
+	config.ID = componentID
+	config.Name = "Smoke Stellar Source"
+	config.Description = "Fetches a tiny bounded ledger range from Stellar RPC"
+	config.Version = "smoke"
+	config.Endpoint = port
+	config.HealthPort = healthPort
+	config.OutputEventTypes = []string{"stellar.ledger.v1"}
+	config.FlowctlConfig = &flowctlpkg.Config{
+		Enabled:           enableFlowctl,
+		Endpoint:          flowctlEndpoint,
+		ServiceID:         componentID,
+		ServiceType:       flowctlpkg.ServiceTypeSource,
+		HeartbeatInterval: flowctlpkg.DefaultHeartbeatInterval,
+		Metadata:          map[string]string{"rpc_endpoint": rpcEndpoint},
+		OutputEventTypes:  []string{"stellar.ledger.v1"},
+	}
+
+	src, err := source.New(config)
+	if err != nil {
+		log.Fatalf("create source: %v", err)
+	}
+
+	backend := ledgerbackend.NewRPCLedgerBackend(ledgerbackend.RPCLedgerBackendOptions{
+		RPCServerURL: rpcEndpoint,
+		BufferSize:   4,
+	})
+	defer backend.Close()
+
+	ctx := context.Background()
+	if err := backend.PrepareRange(ctx, ledgerbackend.BoundedRange(startLedger, endLedger)); err != nil {
+		log.Fatalf("prepare range: %v", err)
+	}
+
+	err = src.OnProduce(func(ctx context.Context, req *flowctlv1.StreamRequest) (<-chan *flowctlv1.Event, error) {
+		ch := make(chan *flowctlv1.Event, 4)
+		go func() {
+			defer close(ch)
+			for seq := startLedger; seq <= endLedger; seq++ {
+				ledger, err := backend.GetLedger(ctx, seq)
+				if err != nil {
+					log.Printf("get ledger %d: %v", seq, err)
+					return
+				}
+				xdrBytes, err := ledger.MarshalBinary()
+				if err != nil {
+					log.Printf("marshal xdr %d: %v", seq, err)
+					return
+				}
+				payload, err := proto.Marshal(&stellarv1.RawLedger{
+					Sequence:           seq,
+					LedgerCloseMetaXdr: xdrBytes,
+					Network:            "public",
+				})
+				if err != nil {
+					log.Printf("marshal proto %d: %v", seq, err)
+					return
+				}
+				event := &flowctlv1.Event{
+					Id:          fmt.Sprintf("ledger-%d", seq),
+					Type:        "stellar.ledger.v1",
+					Payload:     payload,
+					Metadata:    map[string]string{"ledger_sequence": fmt.Sprintf("%d", seq)},
+					ContentType: "application/protobuf",
+					StellarCursor: &flowctlv1.StellarCursor{
+						LedgerSequence: uint64(seq),
+					},
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case ch <- event:
+					log.Printf("emitted ledger %d", seq)
+				}
+			}
+			log.Printf("finished emitting ledgers %d-%d", startLedger, endLedger)
+		}()
+		return ch, nil
+	})
+	if err != nil {
+		log.Fatalf("register producer: %v", err)
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if err := src.Start(runCtx); err != nil {
+		log.Fatalf("start source: %v", err)
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	<-sigCh
+	_ = src.Stop()
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func mustInt(v string) int {
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+var _ xdr.LedgerCloseMeta
+EOF
+
+cat > "$WORK_DIR/sink.go" <<'EOF'
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"sync/atomic"
+
+	"github.com/withObsrvr/flowctl-sdk/pkg/consumer"
+	flowctlv1 "github.com/withObsrvr/flow-proto/go/gen/flowctl/v1"
+)
+
+func main() {
+	componentID := getenv("FLOWCTL_COMPONENT_ID", getenv("COMPONENT_ID", "token-transfer-sink"))
+	countFile := getenv("COUNT_FILE", "./sink-count.txt")
+	var count atomic.Int64
+
+	consumer.Run(consumer.ConsumerConfig{
+		ConsumerName: "Token Transfer Smoke Sink",
+		ComponentID:  componentID,
+		InputTypes:   []string{"stellar.token.transfer.v1"},
+		OnEvent: func(ctx context.Context, event *flowctlv1.Event) error {
+			n := count.Add(1)
+			f, err := os.OpenFile(countFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+			if _, err := f.WriteString(event.Id + "\n"); err != nil {
+				return err
+			}
+			log.Printf("received token transfer batch event %s (count=%d, payload=%d bytes)", event.Id, n, len(event.Payload))
+			return nil
+		},
+	})
+}
+
+func getenv(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+EOF
+
+cat > "$WORK_DIR/pipeline.yaml" <<EOF
+apiVersion: flowctl/v1
+kind: Pipeline
+metadata:
+  name: token-transfer-smoke
+spec:
+  driver: process
+  sources:
+    - id: stellar-source
+      command: ["$WORK_DIR/stellar-source"]
+      env:
+        ENABLE_FLOWCTL: "true"
+        FLOWCTL_ENDPOINT: "127.0.0.1:$CONTROL_PLANE_PORT"
+        COMPONENT_ID: "stellar-source"
+        PORT: ":$SOURCE_PORT"
+        HEALTH_PORT: "$SOURCE_HEALTH_PORT"
+        RPC_ENDPOINT: "$RPC_ENDPOINT"
+        START_LEDGER: "$START_LEDGER"
+        END_LEDGER: "$END_LEDGER"
+  processors:
+    - id: token-transfer
+      command: ["$WORK_DIR/token-transfer-processor"]
+      inputs: ["stellar-source"]
+      env:
+        ENABLE_FLOWCTL: "true"
+        FLOWCTL_ENDPOINT: "127.0.0.1:$CONTROL_PLANE_PORT"
+        COMPONENT_ID: "token-transfer"
+        NETWORK_PASSPHRASE: "$NETWORK_PASSPHRASE"
+        PORT: ":$PROCESSOR_PORT"
+        HEALTH_PORT: "$PROCESSOR_HEALTH_PORT"
+  sinks:
+    - id: token-transfer-sink
+      command: ["$WORK_DIR/token-transfer-sink"]
+      inputs: ["token-transfer"]
+      env:
+        ENABLE_FLOWCTL: "true"
+        FLOWCTL_ENDPOINT: "127.0.0.1:$CONTROL_PLANE_PORT"
+        COMPONENT_ID: "token-transfer-sink"
+        PORT: ":$SINK_PORT"
+        HEALTH_PORT: "$SINK_HEALTH_PORT"
+        COUNT_FILE: "$WORK_DIR/sink-count.txt"
+EOF
+
+echo "==> downloading released processor $RELEASE_TAG"
+cd "$WORK_DIR"
+gh release download "$RELEASE_TAG" -R withObsrvr/flowctl-token-transfer-processor -p 'token-transfer-processor-linux-amd64.tar.gz'
+tar -xzf token-transfer-processor-linux-amd64.tar.gz
+chmod +x token-transfer-processor
+./token-transfer-processor --version
+
+echo "==> building smoke source and sink"
+go mod tidy
+GOFLAGS='' go build -o stellar-source source.go
+GOFLAGS='' go build -o token-transfer-sink sink.go
+
+echo "==> building flowctl"
+cd "$ROOT_DIR"
+make build >/dev/null
+
+echo "==> validating pipeline"
+"$FLOWCTL_BIN" validate "$WORK_DIR/pipeline.yaml"
+
+echo "==> starting pipeline"
+cd "$WORK_DIR"
+rm -f sink-count.txt run.log status.out processors.out active.out runinfo.out stop.out
+"$FLOWCTL_BIN" run --show-status=false --no-persistence --log-dir "$LOG_DIR" --control-plane-port "$CONTROL_PLANE_PORT" "$WORK_DIR/pipeline.yaml" > run.log 2>&1 &
+FLOWCTL_PID=$!
+echo "flowctl pid: $FLOWCTL_PID"
+
+echo "==> waiting for all components to register"
+STATUS_OUT=$(wait_for_contains 120 'Components: 3 total (3 healthy)' "$FLOWCTL_BIN" status --control-plane-addr "127.0.0.1:$CONTROL_PLANE_PORT")
+printf '%s\n' "$STATUS_OUT" | tee status.out
+
+echo "==> checking processors list"
+"$FLOWCTL_BIN" processors list --endpoint "127.0.0.1:$CONTROL_PLANE_PORT" > processors.out
+cat processors.out
+
+echo "==> waiting for active pipeline run"
+ACTIVE_OUT=$(wait_for_contains 60 'token-transfer-smoke' "$FLOWCTL_BIN" pipelines active --control-plane-address 127.0.0.1 --control-plane-port "$CONTROL_PLANE_PORT")
+printf '%s\n' "$ACTIVE_OUT" | tee active.out
+RUN_ID=$(printf '%s\n' "$ACTIVE_OUT" | awk 'NF && $1 != "RUN" && $1 != "Found" && $1 != "No" {print $1; exit}')
+if [[ -z "$RUN_ID" ]]; then
+  echo "failed to parse run id from active output" >&2
+  exit 1
+fi
+
+echo "==> checking run-info for $RUN_ID"
+"$FLOWCTL_BIN" pipelines run-info "$RUN_ID" --control-plane-address 127.0.0.1 --control-plane-port "$CONTROL_PLANE_PORT" > runinfo.out
+cat runinfo.out
+
+echo "==> waiting for sink to receive events"
+for i in $(seq 1 180); do
+  [[ -s sink-count.txt ]] && break
+  sleep 1
+done
+if [[ ! -s sink-count.txt ]]; then
+  echo "sink did not receive any events" >&2
+  tail -n 200 run.log >&2 || true
+  find "$LOG_DIR" -maxdepth 1 -type f -name '*.log' -print -exec tail -n 100 {} \; >&2 || true
+  exit 1
+fi
+cat sink-count.txt
+
+echo "==> stopping pipeline"
+"$FLOWCTL_BIN" pipelines stop "$RUN_ID" --control-plane-address 127.0.0.1 --control-plane-port "$CONTROL_PLANE_PORT" > stop.out
+cat stop.out
+
+wait "$FLOWCTL_PID" || true
+
+echo "==> final artifacts"
+echo "work dir: $WORK_DIR"
+echo "logs: $WORK_DIR/run.log"
+echo "component logs: $LOG_DIR"
+echo "smoke test passed"


### PR DESCRIPTION
This pull request introduces comprehensive documentation for reference processors in `flowctl`, clarifies the recommended development path for processor authors, and updates example and component-building documentation to reference these new resources. The main goal is to provide a clear, teachable, and production-focused set of processor patterns and guidance for both new and advanced users.

**Documentation of reference processors and development workflow:**

* Added a new document, `REFERENCE_PROCESSORS.md`, detailing the initial set of reference processors, their selection criteria, implementation order, and deliverables. This document also explains the relationship between prototyping in `nebu` and productionizing in `flowctl`, and provides example pipeline chains for documentation and demos.
* Updated `building-components.md` to direct processor authors to the new processor-focused guides, explicitly outlining the prototype-to-production workflow using `nebu` and `flowctl`.

**Improvements to example and component-building documentation:**

* Enhanced `examples/README.md` to reference both the general and processor-specific building guides, making it easier for users to find the right documentation for building custom pipelines and components. [[1]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9L49-R49) [[2]](diffhunk://#diff-49aaa2819e35a856818ecec8c9fa7e1c79ad028d3f44bd749736353cfb51bac9R169)
* Clarified the intermediate steps in `examples/README.md` to encourage building processors as well as sources and sinks.