### PR TITLE
update install

### DIFF
--- a/docs/init-command.md
+++ b/docs/init-command.md
@@ -122,7 +122,7 @@ When you run a pipeline created by `flowctl init`, components are automatically 
 |-----------|-------|------|-------------|
 | Stellar Live Source | `docker.io/withobsrvr/stellar-live-source:v1.0.0` | Source | Streams Stellar ledger data in real-time |
 | DuckDB Consumer | `docker.io/withobsrvr/duckdb-consumer:v1.0.0` | Sink | Writes data to embedded DuckDB database |
-| PostgreSQL Sink | `docker.io/withobsrvr/postgres-sink:v1.0.0` | Sink | Writes data to PostgreSQL database |
+| PostgreSQL Sink | `docker.io/withobsrvr/postgres-consumer:v1.0.0` | Sink | Writes data to PostgreSQL database |
 
 ### Registry Information
 
@@ -137,7 +137,7 @@ To pre-download components:
 ```bash
 docker pull docker.io/withobsrvr/stellar-live-source:v1.0.0
 docker pull docker.io/withobsrvr/duckdb-consumer:v1.0.0
-docker pull docker.io/withobsrvr/postgres-sink:v1.0.0
+docker pull docker.io/withobsrvr/postgres-consumer:v1.0.0
 ```
 
 ## Generated Configuration Structure

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env sh
 set -eu
 
-REPO="withobsrvr/flowctl"
+REPO="withObsrvr/flowctl"
 BIN="flowctl"
 INSTALL_DIR="${INSTALL_DIR:-${HOME}/.local/bin}"
 VERSION="${VERSION:-latest}"
+TAG_VERSION=""
+ASSET_VERSION=""
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -53,23 +55,35 @@ case "$arch" in
 esac
 
 if [ "$VERSION" = "latest" ]; then
-  VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | \
+  TAG_VERSION=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | \
     grep '"tag_name":' | head -n1 | sed -E 's/.*"([^"]+)".*/\1/')
+  ASSET_VERSION="${TAG_VERSION#v}"
+else
+  case "$VERSION" in
+    v*)
+      TAG_VERSION="$VERSION"
+      ASSET_VERSION="${VERSION#v}"
+      ;;
+    *)
+      TAG_VERSION="v$VERSION"
+      ASSET_VERSION="$VERSION"
+      ;;
+  esac
 fi
 
-if [ -z "$VERSION" ]; then
+if [ -z "$TAG_VERSION" ] || [ -z "$ASSET_VERSION" ]; then
   echo "error: failed to resolve release version" >&2
   exit 1
 fi
 
-archive="${BIN}_${VERSION}_${os}_${arch}.tar.gz"
-url="https://github.com/${REPO}/releases/download/${VERSION}/${archive}"
-checksum_url="https://github.com/${REPO}/releases/download/${VERSION}/checksums.txt"
+archive="${BIN}_${ASSET_VERSION}_${os}_${arch}.tar.gz"
+url="https://github.com/${REPO}/releases/download/${TAG_VERSION}/${archive}"
+checksum_url="https://github.com/${REPO}/releases/download/${TAG_VERSION}/checksums.txt"
 
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT INT TERM
 
-echo "Installing ${BIN} ${VERSION} for ${os}/${arch}..."
+echo "Installing ${BIN} ${TAG_VERSION} for ${os}/${arch}..."
 echo "Downloading ${url}"
 
 curl -fL "$url" -o "$tmpdir/$archive"

--- a/stellar-pipeline.yaml
+++ b/stellar-pipeline.yaml
@@ -24,6 +24,6 @@ spec:
             backend_type: RPC
             network_passphrase: Test SDF Network ; September 2015
             rpc_endpoint: https://soroban-testnet.stellar.org
-            start_ledger: 567876
+            start_ledger: 2191326
           id: stellar-source
           type: stellar-live-source@v1.0.0


### PR DESCRIPTION
This pull request updates the `docs/install.sh` script to improve version handling and corrects the repository casing, and also updates the starting ledger in the `stellar-pipeline.yaml` configuration. The main focus is on making the install script more robust and compatible with different version formats.

**Install script improvements:**

* Changed `REPO` from `withobsrvr/flowctl` to `withObsrvr/flowctl` to match the correct GitHub repository casing.
* Refactored version resolution logic to distinguish between tag version (`TAG_VERSION`) and asset version (`ASSET_VERSION`), supporting both `vX.Y.Z` and `X.Y.Z` formats for manual and latest releases.
* Updated archive and download URL construction to use the new version variables, ensuring correct asset retrieval for all version formats.
* Improved error handling to check both `TAG_VERSION` and `ASSET_VERSION` are set before proceeding.

**Configuration update:**

* Updated `start_ledger` in `stellar-pipeline.yaml` from `567876` to `2191326` to use a more recent starting point for the Stellar test network.